### PR TITLE
Implemented reset method

### DIFF
--- a/crc8.py
+++ b/crc8.py
@@ -80,6 +80,7 @@ class crc8(object):
     def __init__(self, initial_string=b'', initial_start=0x00):
         """Create a new crc8 hash instance."""
         self._sum = initial_start
+        self._initial_start = initial_start
         self._update(initial_string)
 
     def update(self, bytes_):
@@ -147,5 +148,8 @@ class crc8(object):
         crc = crc8()
         crc._sum = self._sum
         return crc
+
+    def reset(self):
+        self._sum = self._initial_start
 
 __all__ = ['crc8']

--- a/test_crc8.py
+++ b/test_crc8.py
@@ -140,6 +140,14 @@ def test_copy():
     assert crc2.copy() != crc
 
 
+def test_reset():
+    crc = crc8()
+    crc.update(b'asd')
+    crc.reset()
+    crc.update(b'abc')
+    assert crc.digest() == CRC8_ABC
+
+
 def test_initialize_with_bytes():
     assert crc8(b'123').digest() == CRC8_123
 


### PR DESCRIPTION
Implemented reset method to allow reusage of the same CRC8 object when one wants to calculate a new crc value without the history of previous updates.

#8 